### PR TITLE
Remove Timeout from http Client initialization. Go Appengine version.

### DIFF
--- a/stripe.go
+++ b/stripe.go
@@ -71,7 +71,8 @@ var Key string
 // 3: errors + informational + debug
 var LogLevel = 2
 
-var httpClient = &http.Client{Timeout: defaultHTTPTimeout}
+// var httpClient = &http.Client{Timeout: defaultHTTPTimeout}
+var httpClient = &http.Client{}
 var backends Backends
 
 // SetHTTPClient overrides the default HTTP client.


### PR DESCRIPTION
Go Stripe package is not compatible with Go 1.2.1. Its minimum is Go 1.3.1.

Needed for Go Appengine Go 1.2.1